### PR TITLE
Use the taxonomy field to select viral metagenomic bins

### DIFF
--- a/pyrodigal_gv/meta.py
+++ b/pyrodigal_gv/meta.py
@@ -16,4 +16,5 @@ with resource_files(__package__).joinpath("meta.json").open("r") as f:
         )
         for b in json.load(f)
     ])
-    METAGENOMIC_BINS_VIRAL = METAGENOMIC_BINS[-12:]
+    METAGENOMIC_BINS_VIRAL = pyrodigal.MetagenomicBins(
+        [b for b in METAGENOMIC_BINS if b.description.split("|")[2] == "V"])


### PR DESCRIPTION
Instead of selecting the last 12 metagenomic bins, we should select the viral models based on the taxonomy field of the description. This should make the selection more robust, in case more models are added in the future.