### PR TITLE
Allow configuring minimum mask length in `ViralGeneFinder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add the `min_mask` argument to `ViralGeneFinder` to control the minimum lenght of masked regions on `mask=True`.
+
 ## [v0.1.0] - 2023-09-17
 [v0.1.0]: https://github.com/althonos/pyrodigal-gv/compare/13f7fb0...v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add the `min_mask` argument to `ViralGeneFinder` to control the minimum lenght of masked regions on `mask=True`.
 
+### Changed
+- Bumped `pyrodigal` dependency to `v3.1`.
+
 ## [v0.1.0] - 2023-09-17
 [v0.1.0]: https://github.com/althonos/pyrodigal-gv/compare/13f7fb0...v0.1.0
 

--- a/pyrodigal_gv/__init__.py
+++ b/pyrodigal_gv/__init__.py
@@ -27,6 +27,7 @@ class ViralGeneFinder(pyrodigal.GeneFinder):
         metagenomic_bins: typing.Optional[pyrodigal.MetagenomicBins] = None,
         closed: bool = False,
         mask: bool = False,
+        min_mask: int = 50,
         min_gene: int = 90,
         min_edge_gene: int = 60,
         max_overlap: int = 60,
@@ -55,6 +56,10 @@ class ViralGeneFinder(pyrodigal.GeneFinder):
                 Defaults to `False`.
             mask (`bool`): Prevent genes from running across regions
                 containing unknown nucleotides. Defaults to `False`.
+            min_mask (`int`): The minimum mask length, when region masking
+                is enabled. Regions shorter than the given length will not
+                be masked, which may be helpful to prevent masking of 
+                single unknown nucleotides.
             min_gene (`int`): The minimum gene length. Defaults to the value
                 used in Prodigal.
             min_edge_gene (`int`): The minimum edge gene length. Defaults to
@@ -78,6 +83,7 @@ class ViralGeneFinder(pyrodigal.GeneFinder):
             metagenomic_bins=metagenomic_bins,
             closed=closed,
             mask=mask,
+            min_mask=min_mask,
             min_gene=min_gene,
             min_edge_gene=min_edge_gene,
             max_overlap=max_overlap,

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ setup_requires =
     wheel >=0.23
     packaging >=19.1
 install_requires =
-    pyrodigal ~=3.0
+    pyrodigal ~=3.1
     importlib-resources ; python_version < '3.9'
 
 [options.package_data]


### PR DESCRIPTION
This PR adds the `min_mask` parameter to `ViralGeneFinder` and bumps Pyrodigal's version requirement to `v3.1`.